### PR TITLE
Remove dependency on checkerframework.checker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.github.hanshsieh</groupId>
   <artifactId>pixivj</artifactId>
-  <version>0.3.0-beta-SNAPSHOT</version>
+  <version>0.3.1-alpha-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>pixivj</name>
@@ -53,8 +53,8 @@
     </dependency>
     <dependency>
       <groupId>org.checkerframework</groupId>
-      <artifactId>checker</artifactId>
-      <version>3.6.0</version>
+      <artifactId>checker-qual</artifactId>
+      <version>3.10.0</version>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>

--- a/src/main/java/com/github/hanshsieh/pixivj/model/Credential.java
+++ b/src/main/java/com/github/hanshsieh/pixivj/model/Credential.java
@@ -1,7 +1,7 @@
 package com.github.hanshsieh.pixivj.model;
 
+import java.util.Objects;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.com.google.common.base.Objects;
 
 public class Credential {
 
@@ -149,18 +149,18 @@ public class Credential {
       return false;
     }
     Credential that = (Credential) other;
-    return Objects.equal(clientId, that.clientId) &&
-        Objects.equal(clientSecret, that.clientSecret) &&
-        Objects.equal(grantType, that.grantType) &&
-        Objects.equal(username, that.username) &&
-        Objects.equal(password, that.password) &&
-        Objects.equal(refreshToken, that.refreshToken) &&
-        Objects.equal(hashSecret, that.hashSecret);
+    return Objects.equals(clientId, that.clientId) &&
+        Objects.equals(clientSecret, that.clientSecret) &&
+        Objects.equals(grantType, that.grantType) &&
+        Objects.equals(username, that.username) &&
+        Objects.equals(password, that.password) &&
+        Objects.equals(refreshToken, that.refreshToken) &&
+        Objects.equals(hashSecret, that.hashSecret);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(
+    return Objects.hash(
         clientId,
         clientSecret,
         grantType,


### PR DESCRIPTION
- Change dependency of checkerframework.checker to
  checkerframework.checker-qual because the two module defines some same
  package, which cause module conflict in Java 9.